### PR TITLE
Modified load.py to disable Insecure Request warnings

### DIFF
--- a/src/load.py
+++ b/src/load.py
@@ -2,6 +2,11 @@ import pandas as pd
 import requests, os
 from pathlib import Path
 import logging
+# urllib3 is a HTTP client library that provides error handling
+from urllib3.exceptions import InsecureRequestWarning
+# Suppress the certificate verfiication/insecure request warnings by using the urllib3 disable warnings method.
+requests.packages.urllib3.disable_warnings(category=InsecureRequestWarning)
+
 logger = logging.getLogger(__name__)
 
 class MissingInput(Exception):


### PR DESCRIPTION
Imported error handling module from urllib3 library that should disable warnings for insecure requests. Discussion on the topic found on [Stack Overflow](https://stackoverflow.com/questions/15445981/how-do-i-disable-the-security-certificate-check-in-pythons-requests). Made this a "global" function so it would apply for all requests. 